### PR TITLE
Use label to make answer clickable

### DIFF
--- a/components/Content/Lesson/AnswerBox.js
+++ b/components/Content/Lesson/AnswerBox.js
@@ -36,7 +36,7 @@ class Answer extends React.Component {
     const { answer, onChange, symbol } = this.props
 
     return (
-      <div>
+      <label>
         {symbol? symbol : (
           <input
             type='radio'
@@ -47,7 +47,8 @@ class Answer extends React.Component {
         )}
         <span>{answer}</span>
         <style jsx>{`
-          div {
+          label {
+            display: block;
             font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
             font-size: 15px;
             margin: 0 0 5px 0;
@@ -67,7 +68,7 @@ class Answer extends React.Component {
             display: inline-block;
           }
         `}</style>
-      </div>
+      </label>
     )
   }
 }


### PR DESCRIPTION
This suggests using a `<label>` instead of `<div>` in the answer box so that answers are clickable.

![use-label](https://cloud.githubusercontent.com/assets/41094/24630224/19b8ce58-1879-11e7-8309-98d3094a28ed.gif)

Thanks for the great software!